### PR TITLE
bug: Improving the validation Tost message

### DIFF
--- a/src/components/pages/auth/register/index.tsx
+++ b/src/components/pages/auth/register/index.tsx
@@ -58,7 +58,11 @@ export default function RegisterComponent() {
     } catch (error: any) {
       console.log(error);
       setRegisterStatus("failure");
-      toastify(error.message, "error");
+      if(error.message.includes('password')){
+        toastify("Oops! Your password should be at least 8 characters and avoid commonly used choices.", "info");
+      }else{
+        toastify(error.message, "error");
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
#77 
## Description

I had fixed the password validation toast message of  register page. Now new Message will be shown is "Oops! Your password should be at least 8 characters and avoid commonly used choices." .
## Screenshots
![index tsx - Open Source 2 - Visual Studio Code 10_19_2023 7_19_39 PM](https://github.com/Sanchitbajaj02/palettegram/assets/104785331/980151e5-8d9d-45bb-8de3-de503cfdcf4c)
