### PR TITLE
feat: added a character counter to notify no of characters

### DIFF
--- a/src/components/core/createPost/index.tsx
+++ b/src/components/core/createPost/index.tsx
@@ -166,7 +166,8 @@ const CreatePost = () => {
       <section className="border border-gray-500 rounded-md shadow-sm mb-4">
         <form className="p-4" method="post" onSubmit={handleSubmit}>
           <div className="mb-2">
-            <small className="text-slate-400">Character limit is upto {CHAR_LIMIT}</small>
+            {/* <small className="text-slate-400">Character limit is upto {CHAR_LIMIT}</small> */}
+            <small className="text-slate-400">You have {CHAR_LIMIT -postTitle.length} characters left</small>
 
             <textarea
               onChange={(event: any) => setPostTitle(event.target.value)}


### PR DESCRIPTION
## Related Issue #161 
- User was not notified about how many characters he has left to input in the post, so the post content gets trimmed after submitting.

## Description
- Modified the post box from "Character limit 500" to "You have 500 characters left"
- Now the max character is still 500 but since the user is notified about the no. of characters left, he can create the content accordingly.

<!-- Please provide more context or information for us to properly rewrite your statement  -->

## Screenshots
- Before Issue : -
![issue_palletegram](https://github.com/Sanchitbajaj02/palettegram/assets/97865752/e648143d-0d75-4b26-b294-cf28579e090b)
 - Resolved : -
![palette_issueFix](https://github.com/Sanchitbajaj02/palettegram/assets/97865752/177202bd-0567-437d-bde6-25cd436c30e4)

 