### PR TITLE
feat: Side contents now sticky as well as responsive.

### DIFF
--- a/src/components/core/trendingFeed/index.tsx
+++ b/src/components/core/trendingFeed/index.tsx
@@ -4,7 +4,7 @@ import { trendingPosts } from "@/backend/trendingPosts.dummy";
 
 export default function TrendingFeed() {
   return (
-    <section className="w-full px-4">
+    <section className="lg:w-64 fixed px-4">
       <h3 className="text-left text-xl font-semibold mb-4 tracking-wide">Trending Posts</h3>
       <div className="mb-4 max-h-96 overflow-y-scroll scrollbar-thin scrollbar-thumb-primary scrollbar-track-secondary-light scrollbar-track-rounded-full">
         {trendingPosts.length &&

--- a/src/components/pages/feed/index.tsx
+++ b/src/components/pages/feed/index.tsx
@@ -17,16 +17,16 @@ const Feed = () => {
   return (
     <>
       <main className="flex sm:flex-row flex-col max-w-screen-lg mx-auto pt-8 content-center px-4  ">
-        <div className=" flex-1 sticky flex sm:flex-col items-center gap-8 ">
+        <div className=" flex-1 sticky flex sm:flex-col items-center gap-8 sm:space-y-20 ">
           <Link
             href={`/user/${userIdFromCookies}`}
-            className="w-12 h-12 rounded-full flex items-center justify-center shadow-md dark:shadow-gray-600 transition-all duration-300 text-black dark:text-white hover:text-primary-light border hover:border-primary-light"
+            className="w-12 h-12 sm:fixed rounded-full flex items-center justify-center shadow-md dark:shadow-gray-600 transition-all duration-300 text-black dark:text-white hover:text-primary-light border hover:border-primary-light"
           >
             <User size={20} />
           </Link>
           <Link
             href="/user/bookmarks"
-            className="w-12 h-12 rounded-full flex items-center justify-center shadow-md dark:shadow-gray-600 transition-all duration-300 text-black dark:text-white hover:text-primary-light border hover:border-primary-light"
+            className="w-12 h-12 sm:fixed rounded-full flex items-center justify-center shadow-md dark:shadow-gray-600 transition-all duration-300 text-black dark:text-white hover:text-primary-light border hover:border-primary-light"
           >
             <Bookmark size={20} />
           </Link>


### PR DESCRIPTION
## Related Issue

Closes #149  

## Description

The left-side user button and bookmark button as well as the right-side trending section are now static and does not scroll up with the scrolling of content. 
**Also, now the changes go with the responsiveness too.**

https://github.com/Sanchitbajaj02/palettegram/assets/132138302/f341811c-a18e-4a25-80f8-da6fff396524