### PR TITLE
fix: footer over-lapping issue resolve

### DIFF
--- a/src/components/core/trendingFeed/index.tsx
+++ b/src/components/core/trendingFeed/index.tsx
@@ -4,7 +4,7 @@ import { trendingPosts } from "@/backend/trendingPosts.dummy";
 
 export default function TrendingFeed() {
   return (
-    <section className="lg:w-64 fixed px-4 inline-block h-screen z-10">
+    <section className="lg:w-64 sticky top-24 px-4 inline-block h-fit z-10">
       <h3 className="text-left text-xl font-semibold mb-4 tracking-wide">Trending Posts</h3>
       <div className="mb-4 max-h-96 overflow-y-scroll scrollbar-thin scrollbar-thumb-primary scrollbar-track-secondary-light scrollbar-track-rounded-full">
         {trendingPosts.length &&

--- a/src/components/pages/user/index.tsx
+++ b/src/components/pages/user/index.tsx
@@ -17,7 +17,7 @@ export default function User({ userId }: { userId: string }) {
 
   return (
     <>
-      <main className="flex sm:flex-row flex-col max-w-screen-lg mx-auto pt-4 content-center  ">
+      <main className="flex sm:flex-row flex-col max-w-screen-lg mx-auto pt-8 content-center  ">
         <section className="flex-[5] h-full mt-4 sm:mt-0 px-4">
           <div className="my-4 flex gap-2 items-center">
             <ArrowLeft


### PR DESCRIPTION
## Related Issue

issue #261 

## Description
Fixed the issue where footer was overlapping with treading posts components.

##Changes
Replace some tailwind class and adjusted consistence with other pages ..

Now the Trending-posts will not overlap instead if reaches to top of footer it'll scrolls with footer as footer is the bottom most element.
