### PR TITLE
fix: email input type to email

### DIFF
--- a/src/components/core/newsletter/index.tsx
+++ b/src/components/core/newsletter/index.tsx
@@ -43,7 +43,7 @@ const Newsletter: React.FC = () => {
         <input
           onChange={(e)=>setSubscriberEmail(e.target.value)}
           name="subscriberEmail"
-          type="text"
+          type="email"
           placeholder="Email Address"
           className="w-full bg-white text-black border border-black py-1 px-3 rounded"
         />


### PR DESCRIPTION
## Related Issue

closes #379 

## Description

The newsletter form had input type of "text" for email. This PR fixes it to be of input type "email".

## Screenshots

![image](https://github.com/user-attachments/assets/f8b3584b-8d80-4437-9acc-bc1541483d60)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Updated the newsletter input field to better validate email addresses by changing the input type from `text` to `email`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->